### PR TITLE
Update CosmosDataSinkExtension.cs to enable support for shared throughput in Cosmos containers

### DIFF
--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -59,7 +59,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
                     containerProperties.PartitionKeyPath = settings.PartitionKeyPath;
                 }
 
-                ThroughputProperties? throughputProperties = settings.IsServerlessAccount
+                ThroughputProperties? throughputProperties = settings.IsServerlessAccount || settings.CreatedContainerMaxThroughput == 0
                     ? null
                     : settings.UseAutoscaleForCreatedContainer
                     ? ThroughputProperties.CreateAutoscaleThroughput(settings.CreatedContainerMaxThroughput ?? 4000)


### PR DESCRIPTION
If the max throughput for this container is 0, don't set a provisioned throughput and the container will then use the shared throughput from the database.